### PR TITLE
Add per_lab beaker snippets

### DIFF
--- a/beaker_snippets/per_lab/lab_env/beaker.ofa.iol.unh.edu
+++ b/beaker_snippets/per_lab/lab_env/beaker.ofa.iol.unh.edu
@@ -1,0 +1,23 @@
+cat << EOF > /etc/profile.d/rh-env.sh
+export LAB_CONTROLLER=beaker.ofa.iol.unh.edu
+export DUMPSERVER=""
+
+# Inside Red Hat, the NFSSERVERS variable points to mounts for each of the RHEL
+# releases supported, so for example
+# rhel5-nfs.blah.foo.bar.redhat.com:/export/home which would then have a
+# a directory structure of <fqdn_of_test_machine>/ and in that directory
+# would be freeform files that can be used in a test setting.
+export NFSSERVERS=""
+
+# The lookaside area is for non-release specific files to be downloaded.
+# Generally, they are user space programs, scripts, or tests that are
+# expected to work on any install and don't need a per-release area.
+# All of the rdma-setup scripts are in this area inside the Red Hat cluster
+export LOOKASIDE=http://builder-01.ofa.iol.unh.edu/lookaside
+
+# This is the root directory for downloading build files.  This is not
+# like something we'll need inside the OFA cluster as we don't have internal,
+# private builds like we do inside Red Hat
+export BUILDURL=http://download.eng.bos.redhat.com
+EOF
+

--- a/beaker_snippets/per_lab/system_post/beaker.ofa.iol.unh.edu
+++ b/beaker_snippets/per_lab/system_post/beaker.ofa.iol.unh.edu
@@ -1,0 +1,4 @@
+{% if ca_cert is defined %}
+fetch /etc/pki/ca-trust/source/anchors/ipa_ca_crt https://beaker.ofa.iol.unh.edu/ipa/ca.crt
+update-ca-trust extract
+{% endif %}

--- a/beaker_snippets/per_lab/system_pre/beaker.ofa.iol.unh.edu
+++ b/beaker_snippets/per_lab/system_pre/beaker.ofa.iol.unh.edu
@@ -1,0 +1,4 @@
+{% if ca_cert is defined %}
+fetch /etc/pki/ca-trust/source/anchors/ipa_ca_crt https://beaker.ofa.iol.unh.edu/ipa/ca.crt
+update-ca-trust extract
+{% endif %}

--- a/beaker_snippets/per_lab/timezone/beaker.ofa.iol.unh.edu
+++ b/beaker_snippets/per_lab/timezone/beaker.ofa.iol.unh.edu
@@ -1,0 +1,1 @@
+timezone {{ timezone|default('America/New_York') }}


### PR DESCRIPTION
This is the first bit of beaker snippets.  Hostnames have been obscured since I should be revealing internal Red Hat system hostnames.  In fact, I've tried to guess what the names will be inside the OFA lab.  But they might need corrections.

Signed-off-by: Doug Ledford <dledford@redhat.com>