### PR TITLE
Fix Fedora 34 unreliable hostname issue

### DIFF
--- a/ansible/setup.sh
+++ b/ansible/setup.sh
@@ -13,4 +13,4 @@ mv /usr/local/bin/ansible* /usr/bin
 
 cd /root/fsdp_setup/ansible
 
-ansible-playbook -i inventory --diff -v setup_host.yml --limit "$(hostname)" --connection=local
+ansible-playbook -i inventory --diff -v setup_host.yml --limit "$(cat /etc/hostname)" --connection=local


### PR DESCRIPTION
This fixes Fedora 34's unreliable hostname issue where the `hostname` command wasn't giving a value of "node-*.ofa.iol.unh.edu". 